### PR TITLE
containerIP tool tries to be a bit smart when looking for an IP

### DIFF
--- a/wundertools/tools/containerIP
+++ b/wundertools/tools/containerIP
@@ -2,10 +2,25 @@
 
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../config.inc"
 
+NODE="${1}"
+if [ -z "${NODE}" ]; then
+	echo "[- no was node specified, did you want to check for 'containerIP www'? -]"
+	exit 1
+fi
+
+
 if [ -z "${COMPOSE_NETWORK}" ]; then
 	FORMAT="{{ .NetworkSettings.IPAddress }}"
 else
-	FORMAT="{{ .NetworkSettings.Networks.${COMPOSE_NETWORK}.IPAddress }}"
+
+	case "${COMPOSE_NETWORK}" in
+		"bridge")
+			FORMAT="{{ .NetworkSettings.IPAddress }}"
+			;;
+		*)
+			FORMAT="{{ .NetworkSettings.Networks.${COMPOSE_NETWORK}.IPAddress }}"
+			;;
+	esac
 fi
 
-docker inspect --format "${FORMAT}" "${PROJECT}_${1}_1"
+docker inspect --format "${FORMAT}" "${PROJECT}_${NODE}_1"

--- a/wundertools/tools/containerIP
+++ b/wundertools/tools/containerIP
@@ -4,7 +4,7 @@ source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../config.inc"
 
 NODE="${1}"
 if [ -z "${NODE}" ]; then
-	echo "[- no was node specified, did you want to check for 'containerIP www'? -]"
+	echo "[- There was no node specified, did you want to check for 'containerIP www'? -]"
 	exit 1
 fi
 


### PR DESCRIPTION
This is a small patch in the containerIP script to make it check some different options for where it can look for the IP.  It also checks to see if you specified which node that you want the IP for, and warns you if you didn't pass anything.
