### PR TITLE
db setup script, makefile, individual docker commands, mysql graceful termination

### DIFF
--- a/wundertools/docker/alpine-mariadb/Dockerfile
+++ b/wundertools/docker/alpine-mariadb/Dockerfile
@@ -1,26 +1,19 @@
 FROM ilari/alpine-mariadb
 MAINTAINER me@me.me
 
-# Pull some args from the build command line (or docker-compose build: args: )
 ARG MYSQL_ROOT_PASSWORD
 ARG MYSQL_DATABASE
 ARG MYSQL_USER
 ARG MYSQL_PASSWORD
 
-# Initial db setup
-# - Secure the db, leaving a lame root password, that can be changed in sub images, or in containers
-# - Make sure that NOBODY can access the server without a password
-# - Kill the anonymous users
-# - Kill off the demo database
-# - Make our changes take effect
-RUN apk --update add mysql-client && \
-	(/usr/bin/mysqld_safe --socket=/var/run/mariadb/mariadb.sock &) && sleep 1 && \
-    mysql -S /var/run/mariadb/mariadb.sock -u root -e "UPDATE mysql.user SET Password=PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User='root'" && \
-    mysql -S /var/run/mariadb/mariadb.sock -u root -e "DELETE FROM mysql.user WHERE User=''" && \
-    mysql -S /var/run/mariadb/mariadb.sock -u root -e "DROP DATABASE test" && \
-    mysql -S /var/run/mariadb/mariadb.sock -u root -e "CREATE DATABASE ${MYSQL_DATABASE}" && \
-    mysql -S /var/run/mariadb/mariadb.sock -u root -e "GRANT ALL ON ${MYSQL_DATABASE}.* to ${MYSQL_USER}@'%' IDENTIFIED BY '${MYSQL_PASSWORD}'" && \
-    mysql -S /var/run/mariadb/mariadb.sock -u root -e "FLUSH PRIVILEGES" &&\
-    apk del mysql-client && \
-    rm -rf /tmp/* && \
-    rm -rf /var/cache/apk/*
+RUN apk --update add mysql-client
+
+# basic setup
+COPY setup.sh /tmp/setup.sh
+RUN /tmp/setup.sh
+RUN rm /tmp/setup.sh
+
+# cleanup
+RUN apk del mysql-client
+RUN rm -rf /tmp/*
+RUN rm -rf /var/cache/apk/*

--- a/wundertools/docker/alpine-mariadb/Makefile
+++ b/wundertools/docker/alpine-mariadb/Makefile
@@ -1,0 +1,30 @@
+IMAGE = alpine-mariadb
+
+build: conf.database conf.user conf.root.pass conf.user.pass
+	docker \
+		build \
+		--build-arg "MYSQL_ROOT_PASSWORD=$(shell cat conf.root.pass)" \
+		--build-arg "MYSQL_DATABASE=$(shell cat conf.database)" \
+		--build-arg "MYSQL_USER=$(shell cat conf.user)" \
+		--build-arg "MYSQL_PASSWORD=$(shell cat conf.user.pass)" \
+		-t "$(IMAGE)" \
+		.
+
+rmi:
+	-docker rmi $(IMAGE)
+
+clean:
+	docker images --filter "dangling=true" -q | xargs -r docker rmi
+	rm -f conf.*
+
+conf.user:
+	read -p "Username: " data && echo "$$data" > "$@"
+
+conf.database:
+	read -p "Database: " data && echo "$$data" > "$@"
+
+conf.user.pass:
+	pwgen -s 20 1 > "$@"
+
+conf.root.pass:
+	pwgen -s 20 1 > "$@"

--- a/wundertools/docker/alpine-mariadb/Makefile
+++ b/wundertools/docker/alpine-mariadb/Makefile
@@ -13,7 +13,7 @@ build: conf.database conf.user conf.root.pass conf.user.pass
 rmi:
 	-docker rmi $(IMAGE)
 
-clean:
+clean: rmi
 	docker ps -a --filter status="exited" --format '{{.ID}}' | xargs -r docker rm
 	docker images --filter "dangling=true" -q | xargs -r docker rmi
 	rm -f conf.*

--- a/wundertools/docker/alpine-mariadb/Makefile
+++ b/wundertools/docker/alpine-mariadb/Makefile
@@ -11,7 +11,7 @@ build: conf.database conf.user conf.root.pass conf.user.pass
 		.
 
 rmi:
-	-docker rmi $(IMAGE)
+	-docker rmi "$(IMAGE)"
 
 clean: rmi
 	docker ps -a --filter status="exited" --format '{{.ID}}' | xargs -r docker rm

--- a/wundertools/docker/alpine-mariadb/Makefile
+++ b/wundertools/docker/alpine-mariadb/Makefile
@@ -14,6 +14,7 @@ rmi:
 	-docker rmi $(IMAGE)
 
 clean:
+	docker ps -a --filter status="exited" --format '{{.ID}}' | xargs -r docker rm
 	docker images --filter "dangling=true" -q | xargs -r docker rmi
 	rm -f conf.*
 

--- a/wundertools/docker/alpine-mariadb/setup.sh
+++ b/wundertools/docker/alpine-mariadb/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+SOCK=/var/run/mariadb/mariadb.sock
+
+export PATH=/bin:/usr/bin
+
+/usr/bin/mysqld_safe --socket="$SOCK" --console &
+sleep 3
+
+# Initial db setup
+# - Secure the db, leaving a lame root password, that can be changed in sub images, or in containers
+# - Make sure that NOBODY can access the server without a password
+# - Kill the anonymous users
+# - Kill off the demo database
+# - Make our changes take effect
+
+echo "Executing SQL"
+mysql -S "$SOCK" -u root <<SQL
+UPDATE mysql.user SET Password=PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User='root';
+DELETE FROM mysql.user WHERE User='';
+DROP DATABASE test;
+CREATE DATABASE ${MYSQL_DATABASE};
+GRANT ALL ON ${MYSQL_DATABASE}.* to ${MYSQL_USER}@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
+FLUSH PRIVILEGES;
+SQL
+
+# end the show gracefully
+killall -TERM mysqld
+sleep 5

--- a/wundertools/docker/alpine-mariadb/setup.sh
+++ b/wundertools/docker/alpine-mariadb/setup.sh
@@ -24,6 +24,10 @@ GRANT ALL ON ${MYSQL_DATABASE}.* to ${MYSQL_USER}@'%' IDENTIFIED BY '${MYSQL_PAS
 FLUSH PRIVILEGES;
 SQL
 
-# end the show gracefully
+echo "Graceful exit of mysqld"
 killall -TERM mysqld
-sleep 5
+while true
+do
+  pgrep mysqld >/dev/null 2>&1 || break
+  sleep 1
+done


### PR DESCRIPTION
- Separated DB setup into separate script.
- Introduced Makefile for smooth workflow.
- Separated Docker commands for better visual overview and easier manageability.
- Fixed problem of not gracefully terminating mysqld.
