### PR TITLE
fix db build failure for "cannot connect to db"

### DIFF
--- a/wundertools/images/ilari/alpine-mariadb/Dockerfile
+++ b/wundertools/images/ilari/alpine-mariadb/Dockerfile
@@ -14,7 +14,7 @@ ARG MYSQL_PASSWORD
 # - Kill off the demo database
 # - Make our changes take effect
 RUN apk --update add mysql-client && \
-	(/usr/bin/mysqld_safe --socket=/var/run/mariadb/mariadb.sock &) && sleep 1 && \
+	(/usr/bin/mysqld_safe --socket=/var/run/mariadb/mariadb.sock &) && sleep 3 && \
     mysql -S /var/run/mariadb/mariadb.sock -u root -e "UPDATE mysql.user SET Password=PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User='root'" && \
     mysql -S /var/run/mariadb/mariadb.sock -u root -e "DELETE FROM mysql.user WHERE User=''" && \
     mysql -S /var/run/mariadb/mariadb.sock -u root -e "DROP DATABASE test" && \


### PR DESCRIPTION
This patch increase a sleep timer during DB build, to give the db server a bit more time to start before creating the application DB, and credentials.

This fixed https://github.com/james-nesbitt/shareddockertools/issues/14

It is not 100% certain that this patch is required, so we can wait for the issue to recur.
