### PR TITLE
added wundertools script to allow use of all commands from anywhere inside the app

### DIFF
--- a/wundertools/config.inc
+++ b/wundertools/config.inc
@@ -19,15 +19,15 @@
 # root path basename, but you can use this to override it.
 #
 #
-PROJECT=""
+#PROJECT=""
 
 ###
 # Some important paths used in the app.  These are autodetermined by
 # default to be ./app and ./wundertools from your root project, but
 # I guess that you could override them here.
 #
-PATH_APP=""
-PATH_WUNDERTOOLS=""
+#PATH_APP=""
+#PATH_WUNDERTOOLS=""
 
 ###
 # A docker image that can be used for developer shell and commands
@@ -98,5 +98,5 @@ export COMPOSE_PROJECT_NAME="${PROJECT}"
 export COMPOSE_FILE="${PATH_WUNDERTOOLS}/compose-default.yml"
 
 if [ -z "${COMPOSE_NETWORK}" ]; then
-    COMPOSE_NETWORK="${PROJECT}_default"
+    COMPOSE_NETWORK="${PROJECT}_internal"
 fi

--- a/wundertools/wundertools
+++ b/wundertools/wundertools
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#####
+# lib executable for wundertools
+#
+# This is a centralized executable for wundertools. it is meant to allow
+# running wundertools commands from anywhere inside your project.
+#
+# To use it, copy of symlimk it to any PATH location, such as ~/bin/wundertools
+# and make sure that it is executable.
+#
+
+# subpath that marks a wundertools project
+SUBPATH_WUNDERTOOLS="/wundertools"
+
+# path executed from
+PATH_EXECUTION="${PATH_EXECUTION:-`pwd`}"
+# path to user home folder (in case)
+PATH_HOME="${PATH_HOME:-${HOME}}"
+
+# Determine project root, and data paths
+PATH_PROJECT="${PATH_EXECUTION}"
+while [ -n "${PATH_PROJECT}" ]; do
+  if [ "${PATH_PROJECT}" == "${PATH_HOME}" ]; then
+  	echo "Could not find any wundertools project."
+    exit 1;
+  fi
+  if [ "${PATH_PROJECT}" == "/" ]; then
+
+  	echo "Could not find any wundertools project."
+    exit 1;
+  fi
+  if [ "${PATH_PROJECT}" == "" ]; then
+
+  	echo "Could not find any wundertools project."
+    exit 1;
+  fi
+  if [ -d "${PATH_PROJECT}${SUBPATH_WUNDERTOOLS}" ]; then
+    PATH_WUNDERTOOLS="${PATH_PROJECT}${SUBPATH_WUNDERTOOLS}"
+    break
+  fi
+
+  PATH_PROJECT="$(dirname "${PATH_PROJECT}")"
+done
+
+COMMAND=$1
+ARGS=${@:2}
+
+#echo "WUNDERTOOLS RUN [PROJECT:${PATH_PROJECT}][WUNDERTOOLS:${PATH_WUNDERTOOLS}][COMMAND:${COMMAND}][ARGS: ${ARGS}"
+
+if [ ! -x "${PATH_WUNDERTOOLS}/${COMMAND}" ]; then
+	echo "No matching command found: ${COMMAND}"
+	exit 1
+fi
+
+source "${PATH_WUNDERTOOLS}/${COMMAND}" ${ARGS}


### PR DESCRIPTION
This patch provides a file that you could copy to any user executable PATH element, which would allow you to run wundertools commands from anywhere inside a wundertools application, using the following syntax:

```
 $/> wundertools {command} {command-args...}
```

For example

```
$/> wundertools compose up -d
$/> wundertools composer update 
$/> wundertools drupal config:import 
$/> wundertools drupal cache:rebuild all 
$/> wundertools drupal user:login:url 1
```

Using it requires copying the wundertools/wundertools bash script to any user executable path (any place in your PATH var, such as ~/bin/ or /usr/local/bin)
