### PR TITLE
Latest quay images

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ similar to vagrant:
 Typically you will need to run composer:
 
     $/> wundertools/composer update
-    $/> wundertools/composer upgrade
+    $/> wundertools/composer install
 
 Then you should be up and running.  See "access my site"
 
@@ -58,13 +58,7 @@ Get more information by looking in the wundertools/docs
 
 ### Accessing my containers
 
-@TODO
-
-### DNS
-
-*** DNS is an open topic that we have not resolved. Consider just using hostfile entries for now.
-
-#### /etc/hosts
+#### Container IP
 
 You can usually rely on a direct route to your container.  To find the IP for any container:
 
@@ -72,4 +66,13 @@ You can usually rely on a direct route to your container.  To find the IP for an
 
 *** Note that on some docker setups, the host has not routed container traffic 
 to the docker subnet (bad host) and so a manual route may be necessary.  The OSX Beta client seems to have this issue, but no route seems avaialable.
+
+#### Container shell
+
+You can get a fast shell inside any of the actual containers using: 
+
+    $/> wundertools/tools/execshell fpm
+
+*** Note that this shell is not as usefull as the featured shell from "wundertools/shell" as most of the service images do not even have bash installed.
+
 

--- a/wundertools/compose-default.yml
+++ b/wundertools/compose-default.yml
@@ -74,7 +74,7 @@ services:
   #
   db: 
     #image: quay.io/wunder/alpine-mariadb
-    image: jamesnesbitt/alpine-mariadb-app
+    image: quay.io/wunder/wundertools-image-fuzzy-mariadb
 
     ####
     # IMAGE BUILD OVERRIDES
@@ -110,7 +110,7 @@ services:
   #
   fpm:
     #image: quay.io/wunder/alpine-php-app
-    image: jamesnesbitt/alpine-php-app
+    image: quay.io/wunder/wundertools-image-fuzzy-php
     volumes_from:
       - source  # FPM gets source code from the source container (should be ReadOnly)
     links:
@@ -132,7 +132,7 @@ services:
   #
   www:
     #image: quay.io/wunder/alpine-nginx-pagespeed-app
-    image: jamesnesbitt/alpine-nginx-pagespeed-app
+    image: quay.io/wunder/wundertools-image-fuzzy-nginx
     environment:
       # If you are using DNSDOCK, this will assign a local DNS entry
       DNSDOCK_ALIAS: www.wunderdemo.docker

--- a/wundertools/composer
+++ b/wundertools/composer
@@ -9,17 +9,17 @@ CONTAINER_ARGS="${@:1}"
 docker run --rm -t -i \
     --net "${COMPOSE_NETWORK}" \
     --hostname=${PROJECT} \
-    --volume="${PATH_APP}/web:/app/web" \
-    --volume="${PATH_APP}/vendor:/app/vendor" \
+    --volumes-from="${PROJECT}_source_1" \
     --volume="${PATH_APP}/scripts:/app/scripts" \
     --volume="${PATH_APP}/composer.json:/app/composer.json" \
     --volume="${PATH_HOME}/.gitconfig:/app/.gitconfig" \
     --volume="${PATH_HOME}/.ssh:/app/.ssh" \
     --entrypoint=/usr/bin/composer \
-    -w=/app/project \
+    -w=/app \
     --name="${PROJECT}_composer" \
-    jamesnesbitt/wunder-developershell \
-    --working-dir=/app/project \
+    --user=app \
+    ${DOCKER_IMAGE_DEVELOPERTOOL} \
+    --working-dir=/app \
     ${CONTAINER_ARGS}
 
 #echo "

--- a/wundertools/composer
+++ b/wundertools/composer
@@ -14,7 +14,7 @@ docker run --rm -t -i \
     --volume="${PATH_APP}/composer.json:/app/composer.json" \
     --volume="${PATH_HOME}/.gitconfig:/app/.gitconfig" \
     --volume="${PATH_HOME}/.ssh:/app/.ssh" \
-    --entrypoint=/usr/bin/composer \
+    --entrypoint=composer \
     -w=/app \
     --name="${PROJECT}_composer" \
     --user=app \

--- a/wundertools/config.inc
+++ b/wundertools/config.inc
@@ -18,13 +18,15 @@
 # images that the system will build.  By default it uses the project
 # root path basename, but you can use this to override it.
 #
+# @NOTE keep this [a-z] and [0-9] for your own sanity
 #
-#PROJECT=""
+#PROJECT="myproject"
 
 ###
 # Some important paths used in the app.  These are autodetermined by
 # default to be ./app and ./wundertools from your root project, but
 # I guess that you could override them here.
+#
 #
 #PATH_APP=""
 #PATH_WUNDERTOOLS=""
@@ -37,7 +39,7 @@
 # It is easier to maintain a single image for this, although each
 # container could of course use it's own image.
 #
-DOCKER_IMAGE_DEVELOPERTOOL="quay.io/wunder/alpine-developershell-james"
+#DOCKER_IMAGE_DEVELOPERTOOL=""
 
 #######################################
 # THINGS THAT AREN'T ALWAYS WORKING YET
@@ -46,14 +48,9 @@ DOCKER_IMAGE_DEVELOPERTOOL="quay.io/wunder/alpine-developershell-james"
 # In general each section here has it's own documentation describing it's issue
 
 
-#
-# Networking id and bridge problem.
-#
-# ERROR: docker: Error response from daemon: network {SOMETHING}_default not found.
-# SHORT ANSWER: try setting this: COMPOSE_NETWORK="bridge"
-# LONG ANSWER: do "docker inspect $CONTAINER" on one of your containers and look for "Networks": {"{NETWORK}"
-#
-#COMPOSE_NETWORK="bridge"  # this makes docker-compose use the shared docker network interface
+
+# nothing here right now
+
 
 
 ################
@@ -80,8 +77,14 @@ fi
 if [ -z "${PATH_WUNDERTOOLS}" ]; then
     PATH_WUNDERTOOLS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 fi
+
+
+SUBPATH_APP="app" # @NOTE THAT IF YOU CHANGE THIS, YOU MIGHT NEED TO CHANGE THE YML FILE BINDS TO MATCH 
+if [ -z "${SUBPATH_APP}" ]; then
+    SUBPATH_APP="app"
+fi
 if [ -z "${PATH_APP}" ]; then
-    PATH_APP="$( cd "$( dirname "${PATH_WUNDERTOOLS}" )" && pwd )/app"
+    PATH_APP="$( cd "$( dirname "${PATH_WUNDERTOOLS}" )" && pwd )/${SUBPATH_APP}"
 fi
 
 if [ ! -f ~/.gitconfig ]; then
@@ -98,6 +101,9 @@ if [ -z "${PROJECT}" ]; then
     PROJECT="$(basename $(cd ${PATH_APP} && cd ../ && pwd))"
 fi
 
+# perform some sanity checks on the project name, to make it safe for docker networks and container names
+PROJECT="${PROJECT,,}" # lower case
+
 #
 # DOCKER COMPOSE
 #
@@ -105,7 +111,7 @@ fi
 # dev image
 if [ -z "${DOCKER_IMAGE_DEVELOPERTOOL}" ]; then
 	# this is just some old image that I (James) have been using for a while.
-    DOCKER_IMAGE_DEVELOPERTOOL="quay.io/wunder/alpine-developershell-james"
+    DOCKER_IMAGE_DEVELOPERTOOL="quay.io/wunder/wundertools-image-fuzzy-developershell"
 fi
 
 # Set some vars use by Docker-Compose. This may not be necessary for us.

--- a/wundertools/drupal
+++ b/wundertools/drupal
@@ -25,14 +25,13 @@ docker run --rm -t -i \
     --net "${COMPOSE_NETWORK}" \
     --hostname=${PROJECT} \
     --link="${PROJECT}_db_1:db.app" \
-    --volume="${PATH_APP}/web:/app/web" \
-    --volume="${PATH_APP}/vendor:/app/vendor" \
+    --volumes-from="${PROJECT}_source_1" \
     --volume="${PATH_APP}/console:/app/.console" \
     --volume="${PATH_APP}/drush:/app/.drush" \
     --volume="${PATH_HOME}/.ssh:/app/.ssh" \
     -w=/app/web \
     --name="${PROJECT}_drupal" \
-    --entrypoint=/app/project/vendor/bin/drupal \
+    --entrypoint=/app/vendor/bin/drupal \
     --user=app \
     ${DOCKER_IMAGE_DEVELOPERTOOL} \
     ${CONTAINER_ARGS}

--- a/wundertools/drush
+++ b/wundertools/drush
@@ -15,13 +15,12 @@ docker run --rm -t -i \
     --net "${COMPOSE_NETWORK}" \
     --hostname=${PROJECT} \
     --link="${PROJECT}_db_1:db.app" \
-    --volume="${PATH_APP}/web:/app/web" \
-    --volume="${PATH_APP}/vendor:/app/vendor" \
+    --volumes-from="${PROJECT}_source_1" \
     --volume="${PATH_APP}/drush:/app/.drush" \
     --volume="${PATH_HOME}/.ssh:/app/.ssh" \
     -w=/app/web \
     --name="${PROJECT}_drush" \
-    --entrypoint=/app/project/vendor/bin/drush \
+    --entrypoint=/app/vendor/bin/drush \
     --user=app \
     ${DOCKER_IMAGE_DEVELOPERTOOL} \
     ${CONTAINER_ARGS}

--- a/wundertools/shell
+++ b/wundertools/shell
@@ -12,8 +12,7 @@ docker run --rm -t -i \
     --link="${PROJECT}_db_1:db.app" \
     --link="${PROJECT}_fpm_1:fpm.app" \
     --link="${PROJECT}_www_1:www.app" \
-    --volume="${PATH_APP}/web:/app/web" \
-    --volume="${PATH_APP}/vendor:/app/vendor" \
+    --volumes-from="${PROJECT}_source_1" \
     --volume="${PATH_APP}/scripts:/app/scripts" \
     --volume="${PATH_APP}/composer.json:/app/composer.json" \
     --volume="${PATH_APP}/console:/app/.console" \

--- a/wundertools/tools/execshell
+++ b/wundertools/tools/execshell
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../config.inc"
+
+# Which node to shell into
+NODE="${1}"
+if [ -z "${NODE}" ]; then
+	echo "[- There was no node specified, did you want to check for 'containerIP www'? -]"
+	exit 1
+fi
+
+# What command to run
+SHELL="${2:-/bin/sh}"
+
+# echo ">>>>>DOCKER:>EXECSHELL START [NODE:$NODE]
+# "
+
+docker exec -t -i "${PROJECT}_${NODE}_1" "${SHELL}"
+
+# echo "
+# <<<<<DOCKER:SHELL END "


### PR DESCRIPTION
This patch includes a refactor related to the latest batch of quay.io images, which are now stable enough to use.

Changelist:
- change all images to quay.io images
- switch from mount app -> /app/project, to mapping app/web and app/vendor into the images
- remap most command workingdirs to reflect proper web-root, and to get webroot mapping from source
- added execshell tool to get a shell in a running container (was in the backlog of commits)
