### PR TITLE
better safe project name

### DIFF
--- a/wundertools/config.inc
+++ b/wundertools/config.inc
@@ -102,7 +102,6 @@ if [ -z "${PROJECT}" ]; then
 fi
 
 # perform some sanity checks on the project name, to make it safe for docker networks and container names
-PROJECT="${PROJECT,,}" # lower case
 PROJECT="$(echo "${PROJECT}" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]')"
 
 #

--- a/wundertools/config.inc
+++ b/wundertools/config.inc
@@ -103,6 +103,7 @@ fi
 
 # perform some sanity checks on the project name, to make it safe for docker networks and container names
 PROJECT="${PROJECT,,}" # lower case
+PROJECT="$(echo "${PROJECT}" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]')"
 
 #
 # DOCKER COMPOSE


### PR DESCRIPTION
this is kind of necessary as docker-compose already strips the hyphen out of what would be the default project name.  This means that the default use case is broken.
