### PR TITLE
Increase composer process timeout from 300 seconds to 600 seconds

### DIFF
--- a/wundertools/composer
+++ b/wundertools/composer
@@ -18,6 +18,7 @@ docker run --rm -t -i \
     -w=/app \
     --name="${PROJECT}_composer" \
     --user=app \
+    -e COMPOSER_PROCESS_TIMEOUT=600 \
     ${DOCKER_IMAGE_DEVELOPERTOOL} \
     --working-dir=/app \
     ${CONTAINER_ARGS}


### PR DESCRIPTION
When having either slow internet connection or just generally slow environment like I do it makes sense to increase the composer process timeout to 600 seconds to allow install cleanly go through.
