### PR TITLE
Init now builds drupal in app, and puts settings in root

### DIFF
--- a/commands/init
+++ b/commands/init
@@ -7,16 +7,24 @@
 #   - Copies into place the default wundertools.settings.inc and compose-default.yml file.
 #
 
-printf "Initialising new Drupal 8 project (drupal-composer/drupal-project) in ${PATH_APP}/app ...\n"
+# Overwrite some the source path settings
+SUBPATH_SOURCE="app"
+PATH_SOURCE="${PATH_APP}/${SUBPATH_SOURCE}"
+
+printf "Initialising new Drupal 8 project (drupal-composer/drupal-project) in ${PATH_SOURCE} ...\n"
 
 # composer create-project of drupal in PATH_APP
 cd "${PATH_APP}"
-"${PATH_WUNDERTOOLS}/wundertools" composer --pwd create-project drupal-composer/drupal-project:8.x-dev app --stability dev --no-interaction
+"${PATH_WUNDERTOOLS}/wundertools" composer --pwd create-project drupal-composer/drupal-project:8.x-dev "${SUBPATH_SOURCE}" --stability dev --no-interaction
 
 printf "Initialising default settings...\n"
 
+# Copy the default settings to the project root (it is largely an empty template)
+echo "--> creating new settings file"
 cp "${PATH_WUNDERTOOLS}/${WUNDERTOOLS_SETTINGS_FILENAME}" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
-sed -i 's/^#SUBPATH_SOURCE=""/SUBPATH_SOURCE="app"/' "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
+# the only change we make to the settings is to tell wundertools that the source is at ./app
+echo "--> configuring settings file with new source path '${SUBPATH_SOURCE}'"
+sed -i 's/^#SUBPATH_SOURCE=""/SUBPATH_SOURCE="${SUBPATH_SOURCE}"/' "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
 
 # Instructions
 echo "

--- a/commands/init
+++ b/commands/init
@@ -7,25 +7,29 @@
 #   - Copies into place the default wundertools.settings.inc and compose-default.yml file.
 #
 
-printf "Initialising new Drupal 8 project (drupal-composer/drupal-project) in ${PATH_APP} ...\n"
+printf "Initialising new Drupal 8 project (drupal-composer/drupal-project) in ${PATH_APP}/app ...\n"
 
-"${PATH_WUNDERTOOLS}/wundertools" composer --pwd create-project drupal-composer/drupal-project:8.x-dev temp --stability dev --no-interaction
-cp -a "${PATH_APP}/temp/*" "${PATH_APP}"
-rm -rf "${PATH_APP}/temp"
+# composer create-project of drupal in PATH_APP
+cd "${PATH_APP}"
+"${PATH_WUNDERTOOLS}/wundertools" composer --pwd create-project drupal-composer/drupal-project:8.x-dev app --stability dev --no-interaction
 
 printf "Initialising default settings...\n"
 
-cp "${PATH_WUNDERTOOLS}/wundertools.settings.inc" "${PATH_APP}"
-#cp "${PATH_WUNDERTOOLS}/compose-default.yml" "${PATH_APP}/docker-compose.yml.example"
+cp "${PATH_WUNDERTOOLS}/${WUNDERTOOLS_SETTINGS_FILENAME}" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
+sed -i 's/^#SUBPATH_SOURCE=""/SUBPATH_SOURCE="app"/' "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
 
+# Instructions
 echo "
 ------ INIT COMPLETE ------------
 
-Drupal 8 has been built into the curent path, and 
+Drupal 8 has been built into the curent path, and
 a new wundertools.settings.inc file has been added
 which you can modify to alter your system.
 
-If you have a custom docker-compose.yml file, you 
+Wundertools now expects your source code to be in
+the /app path, next to the wundertools folder.
+
+If you have a custom docker-compose.yml file, you
 can add it the project root, next to the wundertools
 folder.  If you want to create one, you can start
 with the composer-default.yml file in the wundertools

--- a/commands/init
+++ b/commands/init
@@ -15,7 +15,7 @@ printf "Initialising new Drupal 8 project (drupal-composer/drupal-project) in ${
 
 # composer create-project of drupal in PATH_APP
 cd "${PATH_APP}"
-#"${PATH_WUNDERTOOLS}/wundertools" composer --pwd create-project drupal-composer/drupal-project:8.x-dev "${SUBPATH_SOURCE}" --stability dev --no-interaction
+"${PATH_WUNDERTOOLS}/wundertools" composer --pwd create-project drupal-composer/drupal-project:8.x-dev "${SUBPATH_SOURCE}" --stability dev --no-interaction
 
 printf "Initialising default settings...\n"
 

--- a/commands/init
+++ b/commands/init
@@ -15,7 +15,7 @@ printf "Initialising new Drupal 8 project (drupal-composer/drupal-project) in ${
 
 # composer create-project of drupal in PATH_APP
 cd "${PATH_APP}"
-"${PATH_WUNDERTOOLS}/wundertools" composer --pwd create-project drupal-composer/drupal-project:8.x-dev "${SUBPATH_SOURCE}" --stability dev --no-interaction
+#"${PATH_WUNDERTOOLS}/wundertools" composer --pwd create-project drupal-composer/drupal-project:8.x-dev "${SUBPATH_SOURCE}" --stability dev --no-interaction
 
 printf "Initialising default settings...\n"
 
@@ -24,7 +24,7 @@ echo "--> creating new settings file"
 cp "${PATH_WUNDERTOOLS}/${WUNDERTOOLS_SETTINGS_FILENAME}" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
 # the only change we make to the settings is to tell wundertools that the source is at ./app
 echo "--> configuring settings file with new source path '${SUBPATH_SOURCE}'"
-sed -i 's/^#SUBPATH_SOURCE=""/SUBPATH_SOURCE="${SUBPATH_SOURCE}"/' "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
+sed -i "s/^#SUBPATH_SOURCE=\"\"/SUBPATH_SOURCE=\"${SUBPATH_SOURCE}\"/" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
 
 # Instructions
 echo "

--- a/commands/init
+++ b/commands/init
@@ -7,21 +7,33 @@
 #   - Copies into place the default wundertools.settings.inc and compose-default.yml file.
 #
 
-printf "Initialising new Drupal 8 project (drupal-composer/drupal-project) in the current folder...\n"
+printf "Initialising new Drupal 8 project (drupal-composer/drupal-project) in ${PATH_APP} ...\n"
 
-"${PATH_WUNDERTOOLS}/wundertools" composer create-project drupal-composer/drupal-project:8.x-dev temp --stability dev --no-interaction
-cd "${PATH_WUNDERTOOLS}/../temp"
-cp -a . ../
-cd ..
-rm -rf temp
-
-if [ ! -d "${PATH_WUNDERTOOLS}/../app" ]
-then
-  printf "Initialising app folder...\n"
-  mkdir -p "${PATH_WUNDERTOOLS}/../app"
-fi
+"${PATH_WUNDERTOOLS}/wundertools" composer --pwd create-project drupal-composer/drupal-project:8.x-dev temp --stability dev --no-interaction
+cp -a "${PATH_APP}/temp/*" "${PATH_APP}"
+rm -rf "${PATH_APP}/temp"
 
 printf "Initialising default settings...\n"
 
-cp "${PATH_WUNDERTOOLS}/wundertools.settings.inc" "${PATH_WUNDERTOOLS}/../app"
-cp "${PATH_WUNDERTOOLS}/compose-default.yml" "${PATH_WUNDERTOOLS}/../app"
+cp "${PATH_WUNDERTOOLS}/wundertools.settings.inc" "${PATH_APP}"
+#cp "${PATH_WUNDERTOOLS}/compose-default.yml" "${PATH_APP}/docker-compose.yml.example"
+
+echo "
+------ INIT COMPLETE ------------
+
+Drupal 8 has been built into the curent path, and 
+a new wundertools.settings.inc file has been added
+which you can modify to alter your system.
+
+If you have a custom docker-compose.yml file, you 
+can add it the project root, next to the wundertools
+folder.  If you want to create one, you can start
+with the composer-default.yml file in the wundertools
+folder, but try to remove the shell variables from it.
+
+The initial composer actions have been run, so you
+should be able to get started using:
+
+    $/> wundertools up
+
+"

--- a/compose-default.yml
+++ b/compose-default.yml
@@ -62,8 +62,8 @@ services:
       # recommended, as it creates a dependency on the host environment.  
       # consider creating a more formal layout instead.
       #
-      - ${PATH_APP}/web:/app/web 
-      - ${PATH_APP}/vendor:/app/vendor
+      - ${PATH_SOURCE}/web:/app/web 
+      - ${PATH_SOURCE}/vendor:/app/vendor
 
   ####
   # DB node 


### PR DESCRIPTION
This patch continues effort on https://github.com/wunderkraut/wundertools-dockerprototype/issues/49

Init is now refactored to:
- use more system paths
- drupal compose create-project runs directly into app folder (no need for cp and rm anymore)
- copies only the settings file to the project root (small string replacement to make it work)
- outputs instructions about docker-compose.yml files
