### PR TITLE
added initial run-test command

### DIFF
--- a/commands/runtests
+++ b/commands/runtests
@@ -16,9 +16,10 @@ docker run --rm -t -i \
     --link="${PROJECT}_db_1:db.app" \
     --volumes-from="${PROJECT}_source_1" \
     -w="${CONTAINER_PATH_SOURCE}" \
-    --entrypoint="php" \
+    --entrypoint="/usr/bin/php" \
     ${DOCKER_IMAGE_DEVELOPERTOOL} \
     "${CONTAINER_PATH_SOURCE}/web/core/scripts/run-tests.sh" \
+    --php "/usr/bin/php" \
     ${CONTAINER_ARGS}
 
 # echo "

--- a/commands/runtests
+++ b/commands/runtests
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+####
+# Run Tests
+#
+# Run the Drupal test suite
+#
+
+CONTAINER_ARGS="$@"
+# echo ">>>>>DOCKER:SHELL START [ARGS:${CONTAINER_ARGS}]
+# "
+
+docker run --rm -t -i \
+    --net "${COMPOSE_NETWORK}" \
+    --name="${PROJECT}_runtests" \
+    --hostname=${PROJECT} \
+    --link="${PROJECT}_db_1:db.app" \
+    --volumes-from="${PROJECT}_source_1" \
+    -w="${CONTAINER_PATH_SOURCE}" \
+    --entrypoint="php" \
+    ${DOCKER_IMAGE_DEVELOPERTOOL} \
+    "${CONTAINER_PATH_SOURCE}/web/core/scripts/run-tests.sh" \
+    ${CONTAINER_ARGS}
+
+# echo "
+# <<<<<DOCKER:SHELL END "


### PR DESCRIPTION
Related to https://github.com/wunderkraut/wundertools-dockerprototype/issues/53

this patch adds a new wundertools command "runtests" which runs the drupal run-tests.sh php script in a developer shell.

You will need to either have simpletests installed or pass in a sqlite url that makes sense inside the container.
