### PR TITLE
Apparently when using sed with -i on OS X it needs more

### DIFF
--- a/bootstrap.inc
+++ b/bootstrap.inc
@@ -73,7 +73,7 @@ fi
 if [ -z "${PATH_SOURCE}" ]; then
   if [ -z "${SUBPATH_SOURCE}" ]; then
     PATH_SOURCE="${PATH_APP}"
-  else 
+  else
     PATH_SOURCE="$( cd "${PATH_APP}" && cd "${SUBPATH_SOURCE}" && pwd )"
   fi
 fi
@@ -94,7 +94,7 @@ fi
 ##########################
 # STAGE 2 : DEFAULT VALUES
 #
-# This section tries to autodetermine various values, if they are not 
+# This section tries to autodetermine various values, if they are not
 # already manually defined above.
 #
 
@@ -115,6 +115,9 @@ fi
 
 # perform some sanity checks on the project name, to make it safe for docker networks and container names
 PROJECT="$(echo "${PROJECT}" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]')"
+
+# Detect the OS in some level because some commands like sed work differently on OS X compared to most Linux distributions.
+OS="$(uname)"
 
 #
 # DOCKER COMPOSE
@@ -140,7 +143,7 @@ if [ -z "${COMPOSE_FILE}" ]; then
   fi
 fi
 
-# Here we try to predict what network docker-compose will have created, as 
+# Here we try to predict what network docker-compose will have created, as
 # we will need to know it for some of the commands
 if [ -z "${COMPOSE_NETWORK}" ]; then
     COMPOSE_NETWORK="${PROJECT}_default"
@@ -182,8 +185,8 @@ fi
 PATH_COMMAND="${PATH_COMMANDS}/$1"
 
 if [ ! -f "${PATH_COMMAND}" ]; then
-  PATH_COMMAND="${PATH_COMMANDS}/compose"  
-else 
+  PATH_COMMAND="${PATH_COMMANDS}/compose"
+else
   shift
 fi
 

--- a/commands/init
+++ b/commands/init
@@ -24,7 +24,8 @@ echo "--> creating new settings file"
 cp "${PATH_WUNDERTOOLS}/${WUNDERTOOLS_SETTINGS_FILENAME}" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
 # the only change we make to the settings is to tell wundertools that the source is at ./app
 echo "--> configuring settings file with new source path '${SUBPATH_SOURCE}'"
-sed -i "s/^#SUBPATH_SOURCE=\"\"/SUBPATH_SOURCE=\"${SUBPATH_SOURCE}\"/" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
+sed -i .bak "s/^#SUBPATH_SOURCE=\"\"/SUBPATH_SOURCE=\"${SUBPATH_SOURCE}\"/" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
+rm "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}.bak"
 
 # Instructions
 echo "

--- a/commands/init
+++ b/commands/init
@@ -24,8 +24,13 @@ echo "--> creating new settings file"
 cp "${PATH_WUNDERTOOLS}/${WUNDERTOOLS_SETTINGS_FILENAME}" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
 # the only change we make to the settings is to tell wundertools that the source is at ./app
 echo "--> configuring settings file with new source path '${SUBPATH_SOURCE}'"
-sed -i .bak "s/^#SUBPATH_SOURCE=\"\"/SUBPATH_SOURCE=\"${SUBPATH_SOURCE}\"/" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
-rm "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}.bak"
+if [ $OS = "Darwin" ]
+then
+  sed -i .bak "s/^#SUBPATH_SOURCE=\"\"/SUBPATH_SOURCE=\"${SUBPATH_SOURCE}\"/" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
+  rm "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}.bak"
+else
+  sed -i "s/^#SUBPATH_SOURCE=\"\"/SUBPATH_SOURCE=\"${SUBPATH_SOURCE}\"/" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
+fi
 
 # Instructions
 echo "


### PR DESCRIPTION
Apparently when using sed with -i on OS X, it's required to provide the extension of backup files as argument. This also means we need to remove the backup file afterwards. This should fix #55.
