### PR TITLE
init copies settings from template/demo

### DIFF
--- a/commands/init
+++ b/commands/init
@@ -13,18 +13,17 @@ PATH_SOURCE="${PATH_APP}/${SUBPATH_SOURCE}"
 
 printf "Initialising new Drupal 8 project (drupal-composer/drupal-project) in ${PATH_SOURCE} ...\n"
 
-# composer create-project of drupal in PATH_APP
+# Do everything from the root path (don't do it inside the wundertools folder)
 cd "${PATH_APP}"
+
+# composer create-project of drupal in PATH_APP
 "${PATH_WUNDERTOOLS}/wundertools" composer --pwd create-project drupal-composer/drupal-project:8.x-dev "${SUBPATH_SOURCE}" --stability dev --no-interaction
 
 printf "Initialising default settings...\n"
 
-# Copy the default settings to the project root (it is largely an empty template)
-echo "--> creating new settings file"
-cp "${PATH_WUNDERTOOLS}/${WUNDERTOOLS_SETTINGS_FILENAME}" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
-# the only change we make to the settings is to tell wundertools that the source is at ./app
-echo "--> configuring settings file with new source path '${SUBPATH_SOURCE}'"
-sed -i "s/^#SUBPATH_SOURCE=\"\"/SUBPATH_SOURCE=\"${SUBPATH_SOURCE}\"/" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
+# Copy the demo template settings to the project root (it has on a change for SUBPATH_SOURCE)
+echo "--> creating new settings file from demo template"
+cp "${PATH_WUNDERTOOLS}templates/demo/${WUNDERTOOLS_SETTINGS_FILENAME}" "${PATH_APP}/${WUNDERTOOLS_SETTINGS_FILENAME}"
 
 # Instructions
 echo "

--- a/templates/demo/README.md
+++ b/templates/demo/README.md
@@ -1,0 +1,5 @@
+DEMO TEMPLATE
+-------------
+
+This template folder keeps files that are used in the demo, such as
+a custom settings file, which points to ./app for source.

--- a/templates/demo/wundertools.settings.inc
+++ b/templates/demo/wundertools.settings.inc
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+######################
+# MANUAL CONFIGURATION
+#
+# Here lies manual configrations which you would probably want to
+# base in a config format using yml or json. 
+#
+# We should move this to a central config format as soon as possible
+# to keep such configuration outside of a wundertools concept, so
+# the application layout stays generic, instead of wundertools specific.
+#
+
+####
+# Project name
+#
+# This is primarily used as the root name for all containers and
+# images that the system will build.  By default it uses the project
+# root path basename, but you can use this to override it.
+#
+# @NOTE keep this [a-z] and [0-9] for your own sanity, all other 
+#   characters will be stripped out anyway, to make it behave
+#   predictable with docker-compose
+#
+#PROJECT="myproject"
+
+###
+# Some important paths used in the app.  These are autodetermined by
+# default to be ./app and ./wundertools from your root project, but
+# I guess that you could override them here.
+#
+
+# Set the path to the Wundertools root folder
+#PATH_WUNDERTOOLS=""
+
+# Set the path to the root of your project
+#PATH_APP=""
+# Instead of PATH_APP, you could set the relative path from PATH_WUNDERTOOLS to PATH_APP
+#SUBPATH_APP=""
+
+# Set the path to the root source code for your app
+#PATH_SOURCE=""
+# Or alternatively, set the sub path from PATH_APP to your source Root
+SUBPATH_SOURCE="app"
+
+###
+# Docker compose config
+#
+# Different vars to configure just the docker-compose stuff
+#
+
+# Configure what project name get's used with docker-compose
+# (defaults to $PROJECT)
+#COMPOSE_PROJECT_NAME=""
+
+# Configure what compose yml file gets used.
+# By default the following are checked in this order:
+# - PATH_APP/docker-compose.yml
+# - PATH_APP/compose-$PROJECT.yml
+# - PATH_WUNDERTOOLS/docker-compose.yml
+# - PATH_WUNDERTOOLS/compose-$PROJECT.yml
+# - PATH_WUNDERTOOLS/compose-default.yml
+#
+#COMPOSE_FILE=""
+
+# Configure what network name command containers should use
+#
+# Usually it looks like "$PROJECT_default", but it could be 
+# something else if you have a custom yml file
+#
+
+# Set the network name
+#COMPOSE_NETWORK=""
+# Just set the network suffix
+#COMPOSE_NETWORK_SUFFIX=""
+
+###
+# A docker image that can be used for developer shell and commands
+# Some of the command scripts use this image to run containers as
+# commands; this image provides a base starting point for those
+# containers.
+# It is easier to maintain a single image for this, although each
+# container could of course use it's own image.
+#
+#DOCKER_IMAGE_DEVELOPERTOOL=""


### PR DESCRIPTION
This patch makes init get new settings by copying from the new /templates/demo folder, to avoid using a sed to fix the copied default settings file.

This is an alternate solution to https://github.com/wunderkraut/wundertools-dockerprototype/issues/55

The first solution has a problem with linux https://github.com/wunderkraut/wundertools-dockerprototype/pull/59#issuecomment-221783715

@aleksijohansson still has an idea to fix pull/59 which may be used instead of this.
